### PR TITLE
Move date filtering logic to SQL query

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/caleb531/imessage-conversation-analyzer",
+  "public_key": "pk_mHNGgNfrWVGNBvAnAnLbO"
+}

--- a/ica/queries/attachments.sql
+++ b/ica/queries/attachments.sql
@@ -20,3 +20,4 @@ WHERE
         FROM "chat_message_join"
         WHERE "chat_id" IN ({chat_ids_placeholder})
     )
+{date_filter_clause}

--- a/ica/queries/messages.sql
+++ b/ica/queries/messages.sql
@@ -15,4 +15,6 @@ WHERE "message"."ROWID" IN (
     SELECT "message_id"
     FROM "chat_message_join"
     WHERE "chat_id" IN ({chat_ids_placeholder})
-) ORDER BY "datetime"
+)
+{date_filter_clause}
+ORDER BY "datetime"


### PR DESCRIPTION
This Pull Request moves date range filtering from Pandas to the SQLite query layer, which should improve memory usage and query performance for large conversations.

The previous implementation pulled an entire conversation into memory, and then filtered by date within Pandas. This is not very efficient for large conversations that have narrow date ranges. Since the iMessage `chat.db` has an index against `message.date` (`message_idx_date`), using SQLite to query dates makes it more memory and runtime efficient. 

I haven't changed any method signatures for the public API, so there should be no breaking changes introduced by this PR. 